### PR TITLE
style: 调整全宽度元素的边距和字体大小

### DIFF
--- a/components/Project/Header/index.vue
+++ b/components/Project/Header/index.vue
@@ -61,7 +61,7 @@ defineProps({
     display: flex;
     align-items: center;
     gap: 1rem;
-    font-size: 0.9rem;
+    font-size: 13px;
     height: 44px;
     position: relative;
     &::after {
@@ -104,12 +104,24 @@ defineProps({
 
 @include mixins.respond-to(medium) {
   .project-header {
+    padding-bottom: 35px;
     .meta-info {
       flex-direction: column;
       width: 100%;
+      gap: 10px;
+      padding: 10px 0;
       .type,
       .date {
         width: 100%;
+      }
+      &::after {
+        position: absolute;
+        content: " ";
+        width: 100%;
+        height: 2px;
+        background-color: #000;
+        bottom: -40px;
+        left: 0;
       }
     }
   }

--- a/pages/website/unimate.vue
+++ b/pages/website/unimate.vue
@@ -240,9 +240,7 @@
   margin: variable.$spacing-lg 0;
 
   &.full-width {
-    margin-left: calc(-1 * variable.$spacing-md);
-    margin-right: calc(-1 * variable.$spacing-md);
-    width: calc(100% + 2 * variable.$spacing-md);
+    width: 100%;
   }
 
   img,


### PR DESCRIPTION
简化全宽度元素的边距计算，直接使用100%宽度。调整项目头部元信息的字体大小和间距，并添加底部边框样式。